### PR TITLE
3553 issue fix

### DIFF
--- a/src/service/extract-load-service.ts
+++ b/src/service/extract-load-service.ts
@@ -6,18 +6,18 @@ import { PoolClient } from "pg";
 import unzipper from 'unzipper';
 import path from 'path';
 import { Readable, Transform, Writable } from 'stream';
-import { finished, pipeline } from 'stream/promises';
+import { pipeline } from 'stream/promises';
 import { chain } from 'stream-chain';
 import { parser } from 'stream-json';
 
 import { pick } from 'stream-json/filters/pick.js';
 import { streamArray } from 'stream-json/streamers/stream-array.js';
-import { streamObject } from 'stream-json/streamers/stream-object.js';
 import batch from 'stream-json/utils/batch.js';
-import Fork from 'stream-fork';
 
 
 type UnzipGeoJsonEntry = Readable & { path: string; type: string };
+
+const CHUNK_SIZE = 64 * 1024; // 64KB chunks
 
 export class ExtractLoadRequest {
     data_type!: string;
@@ -57,6 +57,19 @@ export class ExtractLoadService {
         // Stream once: insert features batch-by-batch while collecting root header pairs for the final metadata update.
         const header: Record<string, any> = {};
         let extFileId: number | undefined;
+
+        const utf8Decode = new Transform({
+            transform(chunk: Buffer, _enc, cb) {
+                // chunk could be huge from low-compression zip — split it
+                let offset = 0;
+                while (offset < chunk.length) {
+                    const slice = chunk.slice(offset, offset + CHUNK_SIZE);
+                    this.push(slice.toString('utf8'));
+                    offset += CHUNK_SIZE;
+                }
+                cb();
+            }
+        });
 
         const entryPath = entry.path ?? '';
         const routeKind =
@@ -196,6 +209,7 @@ export class ExtractLoadService {
 
         await pipeline(
             entry,
+            utf8Decode,
             // Stage 1: parse JSON tokens + capture header — all token-level transforms together
             chain([
                 parser(),


### PR DESCRIPTION
## Bug Fix
###  DevBoard Task  
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/3556

### Issue Summary  
- Large GeoJSON files inside low-compression zip archives (ratio ~1x) cause unzipper to emit very large raw buffer chunks. stream-chain's internal fixUtf8Stream attempts to decode these as a single string, hitting V8's 512MB string length limit and crashing.

### Fix Implemented  
- Added a utf8Decode Transform between the unzipper entry stream and the first chain() that splits incoming buffers into 64KB chunks before stream-chain 

### Impacted Areas for Testing  
- Upload and Incline job